### PR TITLE
fix: driver can't resume after S3/S4

### DIFF
--- a/pci.c
+++ b/pci.c
@@ -3029,7 +3029,7 @@ static struct pci_driver rtw89_pci_driver = {
 	.id_table	= rtw89_pci_id_table,
 	.probe		= rtw89_pci_probe,
 	.remove		= rtw89_pci_remove,
-	.driver.pm	= &rtw89_pm_ops,
+	.driver.pm	= NULL,
 };
 module_pci_driver(rtw89_pci_driver);
 


### PR DESCRIPTION
Some BIOSs have trouble changing power state from D3hot to D0