### PR TITLE
small change to suspend_rtw89

### DIFF
--- a/suspend_rtw89
+++ b/suspend_rtw89
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ "${1}" == "pre" ]; then
   modprobe -rv rtw89pci
 elif [ "${1}" == "post" ]; then


### PR DESCRIPTION
When I put my computer to sleep with suspend_rtw89 in /usr/lib/systemd/system-sleep I get the following error:
/usr/lib/systemd/system-sleep/suspend_rtw89: 2: [: pre: unexpected operator
/usr/lib/systemd/system-sleep/suspend_rtw89: 4: [: pre: unexpected operator

The error goes away when I change the shebang to #!/bin/bash, but maybe this would be an issue for users who don't have bash?
