### PR TITLE
Fix suspect pre/post script on Debian

### DIFF
--- a/suspend_rtw89
+++ b/suspend_rtw89
@@ -1,6 +1,6 @@
 #!/bin/sh
-if [ "${1}" == "pre" ]; then
+if [ "${1}" = "pre" ]; then
   modprobe -rv rtw89pci
-elif [ "${1}" == "post" ]; then
+elif [ "${1}" = "post" ]; then
   modprobe -v rtw89pci
 fi


### PR DESCRIPTION
Some distributions, like Debian, have a simple `/bin/sh` shell that is not fully compatible with Bash.