### PR TITLE
Use the AUR correctly and avoid partial upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ For **openSUSE**: Install necessary headers with
 ```bash
 sudo zypper install make gcc kernel-devel kernel-default-devel git libopenssl-devel
 ```
-For **Arch or Manjaro**: Install necessary headers with
+For **Arch**: After installing the necessary kernel headers and base-devel,
 ```bash
-sudo pacman -Sy linuxXYY-headers yay             #X is major version and Y is minor version of kernel (such as 515 for kernel 5.15)
-sudo pacman -Syu dkms base-devel --needed
-yay -Sy rtw89-dkms-git
+git clone https://aur.archlinux.org/rtw89-dkms-git.git
+cd rtw89-dkms-git
+makepkg -sri
 ```
 If any of the packages above are not found check if your distro installs them like that.
 


### PR DESCRIPTION
This updates README.md to use the AUR correctly and avoid partial upgrades.

Closes #101