### PR TITLE
rtw89: Fix build for kernels newer or equal that 5.19

### DIFF
--- a/coex.c
+++ b/coex.c
@@ -4169,6 +4169,7 @@ void rtw89_btc_ntfy_role_info(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif
 
 		rtw89_debug(rtwdev, RTW89_DBG_BTC,
 			    "[BTC], STA support HE=%d VHT=%d HT=%d\n",
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
 			    sta->he_cap.has_he,
 			    sta->vht_cap.vht_supported,
 			    sta->ht_cap.ht_supported);
@@ -4178,6 +4179,17 @@ void rtw89_btc_ntfy_role_info(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif
 			mode |= BIT(BTC_WL_MODE_VHT);
 		if (sta->ht_cap.ht_supported)
 			mode |= BIT(BTC_WL_MODE_HT);
+#else
+			    sta->deflink.he_cap.has_he,
+			    sta->deflink.vht_cap.vht_supported,
+			    sta->deflink.ht_cap.ht_supported);
+		if (sta->deflink.he_cap.has_he)
+			mode |= BIT(BTC_WL_MODE_HE);
+		if (sta->deflink.vht_cap.vht_supported)
+			mode |= BIT(BTC_WL_MODE_VHT);
+		if (sta->deflink.ht_cap.ht_supported)
+			mode |= BIT(BTC_WL_MODE_HT);
+#endif
 
 		r.mode = mode;
 	}

--- a/core.c
+++ b/core.c
@@ -428,10 +428,18 @@ rtw89_core_tx_update_ampdu_info(struct rtw89_dev *rtwdev,
 
 	ampdu_num = (u8)((rtwsta->ampdu_params[tid].agg_num ?
 			  rtwsta->ampdu_params[tid].agg_num :
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 			  4 << sta->ht_cap.ampdu_factor) - 1);
+#else
+			  4 << sta->deflink.ht_cap.ampdu_factor) - 1);
+#endif
 
 	desc_info->agg_en = true;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	desc_info->ampdu_density = sta->ht_cap.ampdu_density;
+#else
+	desc_info->ampdu_density = sta->deflink.ht_cap.ampdu_density;
+#endif
 	desc_info->ampdu_num = ampdu_num;
 }
 
@@ -601,7 +609,11 @@ __rtw89_core_tx_check_he_qos_htc(struct rtw89_dev *rtwdev,
 	if (pkt_type < PACKET_MAX)
 		return false;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (!sta || !sta->he_cap.has_he)
+#else
+	if (!sta || !sta->deflink.he_cap.has_he)
+#endif
 		return false;
 
 	if (!ieee80211_is_data_qos(fc))

--- a/core.h
+++ b/core.h
@@ -3521,11 +3521,21 @@ static inline u8 *get_hdr_bssid(struct ieee80211_hdr *hdr)
 
 static inline bool rtw89_sta_has_beamformer_cap(struct ieee80211_sta *sta)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
 	if ((sta->vht_cap.cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE) ||
 	    (sta->vht_cap.cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE) ||
 	    (sta->he_cap.he_cap_elem.phy_cap_info[3] & IEEE80211_HE_PHY_CAP3_SU_BEAMFORMER) ||
 	    (sta->he_cap.he_cap_elem.phy_cap_info[4] & IEEE80211_HE_PHY_CAP4_MU_BEAMFORMER))
 		return true;
+#else
+	if ((sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE) ||
+	    (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE) ||
+	    (sta->deflink.he_cap.he_cap_elem.phy_cap_info[3] &
+	     		IEEE80211_HE_PHY_CAP3_SU_BEAMFORMER) ||
+	    (sta->deflink.he_cap.he_cap_elem.phy_cap_info[4] &
+	     		IEEE80211_HE_PHY_CAP4_MU_BEAMFORMER))
+		return true;
+#endif
 	return false;
 }
 

--- a/mac.c
+++ b/mac.c
@@ -3950,7 +3950,11 @@ static int rtw89_mac_set_csi_para_reg(struct rtw89_dev *rtwdev,
 	u8 nc = 1, nr = 3, ng = 0, cb = 1, cs = 1, ldpc_en = 1, stbc_en = 1;
 	u8 port_sel = rtwvif->port;
 	u8 sound_dim = 3, t;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	u8 *phy_cap = sta->he_cap.he_cap_elem.phy_cap_info;
+#else
+	u8 *phy_cap = sta->deflink.he_cap.he_cap_elem.phy_cap_info;
+#endif
 	u32 reg;
 	u16 val;
 	int ret;
@@ -3967,12 +3971,21 @@ static int rtw89_mac_set_csi_para_reg(struct rtw89_dev *rtwdev,
 			      phy_cap[5]);
 		sound_dim = min(sound_dim, t);
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if ((sta->vht_cap.cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE) ||
 	    (sta->vht_cap.cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE)) {
 		ldpc_en &= !!(sta->vht_cap.cap & IEEE80211_VHT_CAP_RXLDPC);
 		stbc_en &= !!(sta->vht_cap.cap & IEEE80211_VHT_CAP_RXSTBC_MASK);
 		t = FIELD_GET(IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK,
 			      sta->vht_cap.cap);
+#else
+	if ((sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE) ||
+	    (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE)) {
+		ldpc_en &= !!(sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_RXLDPC);
+		stbc_en &= !!(sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_RXSTBC_MASK);
+		t = FIELD_GET(IEEE80211_VHT_CAP_SOUNDING_DIMENSIONS_MASK,
+			      sta->deflink.vht_cap.cap);
+#endif
 		sound_dim = min(sound_dim, t);
 	}
 	nc = min(nc, sound_dim);
@@ -4013,17 +4026,29 @@ static int rtw89_mac_csi_rrsc(struct rtw89_dev *rtwdev,
 	if (ret)
 		return ret;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->he_cap.has_he) {
+#else
+	if (sta->deflink.he_cap.has_he) {
+#endif
 		rrsc |= (BIT(RTW89_MAC_BF_RRSC_HE_MSC0) |
 			 BIT(RTW89_MAC_BF_RRSC_HE_MSC3) |
 			 BIT(RTW89_MAC_BF_RRSC_HE_MSC5));
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->vht_cap.vht_supported) {
+#else
+	if (sta->deflink.vht_cap.vht_supported) {
+#endif
 		rrsc |= (BIT(RTW89_MAC_BF_RRSC_VHT_MSC0) |
 			 BIT(RTW89_MAC_BF_RRSC_VHT_MSC3) |
 			 BIT(RTW89_MAC_BF_RRSC_VHT_MSC5));
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->ht_cap.ht_supported) {
+#else
+	if (sta->deflink.ht_cap.ht_supported) {
+#endif
 		rrsc |= (BIT(RTW89_MAC_BF_RRSC_HT_MSC0) |
 			 BIT(RTW89_MAC_BF_RRSC_HT_MSC3) |
 			 BIT(RTW89_MAC_BF_RRSC_HT_MSC5));

--- a/phy.c
+++ b/phy.c
@@ -76,10 +76,18 @@ static u64 get_mcs_ra_mask(u16 mcs_map, u8 highest_mcs, u8 gap)
 
 static u64 get_he_ra_mask(struct ieee80211_sta *sta)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	struct ieee80211_sta_he_cap cap = sta->he_cap;
+#else
+	struct ieee80211_sta_he_cap cap = sta->deflink.he_cap;
+#endif
 	u16 mcs_map;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	switch (sta->bandwidth) {
+#else
+	switch (sta->deflink.bandwidth) {
+#endif
 	case IEEE80211_STA_RX_BW_160:
 		if (cap.he_cap_elem.phy_cap_info[0] &
 		    IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_80PLUS80_MHZ_IN_5G)
@@ -174,19 +182,31 @@ static u64 rtw89_phy_ra_mask_cfg(struct rtw89_dev *rtwdev, struct rtw89_sta *rtw
 		return -1;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->he_cap.has_he) {
+#else
+	if (sta->deflink.he_cap.has_he) {
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
 		cfg_mask |= u64_encode_bits(mask->control[band].he_mcs[0],
 					    RA_MASK_HE_1SS_RATES);
 		cfg_mask |= u64_encode_bits(mask->control[band].he_mcs[1],
 					    RA_MASK_HE_2SS_RATES);
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	} else if (sta->vht_cap.vht_supported) {
+#else
+	} else if (sta->deflink.vht_cap.vht_supported) {
+#endif
 		cfg_mask |= u64_encode_bits(mask->control[band].vht_mcs[0],
 					    RA_MASK_VHT_1SS_RATES);
 		cfg_mask |= u64_encode_bits(mask->control[band].vht_mcs[1],
 					    RA_MASK_VHT_2SS_RATES);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	} else if (sta->ht_cap.ht_supported) {
+#else
+	} else if (sta->deflink.ht_cap.ht_supported) {
+#endif
 		cfg_mask |= u64_encode_bits(mask->control[band].ht_mcs[0],
 					    RA_MASK_HT_1SS_RATES);
 		cfg_mask |= u64_encode_bits(mask->control[band].ht_mcs[1],
@@ -227,58 +247,115 @@ static void rtw89_phy_ra_sta_update(struct rtw89_dev *rtwdev,
 
 	memset(ra, 0, sizeof(*ra));
 	/* Set the ra mask from sta's capability */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->he_cap.has_he) {
+#else
+	if (sta->deflink.he_cap.has_he) {
+#endif
 		mode |= RTW89_RA_MODE_HE;
 		csi_mode = RTW89_RA_RPT_MODE_HE;
 		ra_mask |= get_he_ra_mask(sta);
 		high_rate_masks = rtw89_ra_mask_he_rates;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->he_cap.he_cap_elem.phy_cap_info[2] &
+#else
+		if (sta->deflink.he_cap.he_cap_elem.phy_cap_info[2] &
+#endif
 		    IEEE80211_HE_PHY_CAP2_STBC_RX_UNDER_80MHZ)
 			stbc_en = 1;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->he_cap.he_cap_elem.phy_cap_info[1] &
+#else
+		if (sta->deflink.he_cap.he_cap_elem.phy_cap_info[1] &
+#endif
 		    IEEE80211_HE_PHY_CAP1_LDPC_CODING_IN_PAYLOAD)
 			ldpc_en = 1;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	} else if (sta->vht_cap.vht_supported) {
 		u16 mcs_map = le16_to_cpu(sta->vht_cap.vht_mcs.rx_mcs_map);
+#else
+	} else if (sta->deflink.vht_cap.vht_supported) {
+		u16 mcs_map = le16_to_cpu(sta->deflink.vht_cap.vht_mcs.rx_mcs_map);
+#endif
 
 		mode |= RTW89_RA_MODE_VHT;
 		csi_mode = RTW89_RA_RPT_MODE_VHT;
 		/* MCS9, MCS8, MCS7 */
 		ra_mask |= get_mcs_ra_mask(mcs_map, 9, 1);
 		high_rate_masks = rtw89_ra_mask_vht_rates;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->vht_cap.cap & IEEE80211_VHT_CAP_RXSTBC_MASK)
+#else
+		if (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_RXSTBC_MASK)
+#endif
 			stbc_en = 1;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->vht_cap.cap & IEEE80211_VHT_CAP_RXLDPC)
+#else
+		if (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_RXLDPC)
+#endif
 			ldpc_en = 1;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	} else if (sta->ht_cap.ht_supported) {
+#else
+	} else if (sta->deflink.ht_cap.ht_supported) {
+#endif
 		mode |= RTW89_RA_MODE_HT;
 		csi_mode = RTW89_RA_RPT_MODE_HT;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		ra_mask |= ((u64)sta->ht_cap.mcs.rx_mask[3] << 48) |
 			   ((u64)sta->ht_cap.mcs.rx_mask[2] << 36) |
 			   (sta->ht_cap.mcs.rx_mask[1] << 24) |
 			   (sta->ht_cap.mcs.rx_mask[0] << 12);
+#else
+		ra_mask |= ((u64)sta->deflink.ht_cap.mcs.rx_mask[3] << 48) |
+			   ((u64)sta->deflink.ht_cap.mcs.rx_mask[2] << 36) |
+			   (sta->deflink.ht_cap.mcs.rx_mask[1] << 24) |
+			   (sta->deflink.ht_cap.mcs.rx_mask[0] << 12);
+#endif
 		high_rate_masks = rtw89_ra_mask_ht_rates;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->ht_cap.cap & IEEE80211_HT_CAP_RX_STBC)
+#else
+		if (sta->deflink.ht_cap.cap & IEEE80211_HT_CAP_RX_STBC)
+#endif
 			stbc_en = 1;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		if (sta->ht_cap.cap & IEEE80211_HT_CAP_LDPC_CODING)
+#else
+		if (sta->deflink.ht_cap.cap & IEEE80211_HT_CAP_LDPC_CODING)
+#endif
 			ldpc_en = 1;
 	}
 
 	switch (rtwdev->hal.current_band_type) {
 	case RTW89_BAND_2G:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		ra_mask |= sta->supp_rates[NL80211_BAND_2GHZ];
 		if (sta->supp_rates[NL80211_BAND_2GHZ] <= 0xf)
+#else
+		ra_mask |= sta->deflink.supp_rates[NL80211_BAND_2GHZ];
+		if (sta->deflink.supp_rates[NL80211_BAND_2GHZ] <= 0xf)
+#endif
 			mode |= RTW89_RA_MODE_CCK;
 		else
 			mode |= RTW89_RA_MODE_CCK | RTW89_RA_MODE_OFDM;
 		break;
 	case RTW89_BAND_5G:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		ra_mask |= (u64)sta->supp_rates[NL80211_BAND_5GHZ] << 4;
+#else
+		ra_mask |= (u64)sta->deflink.supp_rates[NL80211_BAND_5GHZ] << 4;
+#endif
 		mode |= RTW89_RA_MODE_OFDM;
 		break;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
 	case RTW89_BAND_6G:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		ra_mask |= (u64)sta->supp_rates[NL80211_BAND_6GHZ] << 4;
+#else
+		ra_mask |= (u64)sta->deflink.supp_rates[NL80211_BAND_6GHZ] << 4;
+#endif
 		mode |= RTW89_RA_MODE_OFDM;
 		break;
 #endif
@@ -308,31 +385,60 @@ static void rtw89_phy_ra_sta_update(struct rtw89_dev *rtwdev,
 	ra_mask = rtw89_phy_ra_mask_recover(ra_mask, ra_mask_bak);
 	ra_mask &= rtw89_phy_ra_mask_cfg(rtwdev, rtwsta);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	switch (sta->bandwidth) {
+#else
+	switch (sta->deflink.bandwidth) {
+#endif
 	case IEEE80211_STA_RX_BW_160:
 		bw_mode = RTW89_CHANNEL_WIDTH_160;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		sgi = sta->vht_cap.vht_supported &&
 		      (sta->vht_cap.cap & IEEE80211_VHT_CAP_SHORT_GI_160);
+#else
+		sgi = sta->deflink.vht_cap.vht_supported &&
+		      (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_SHORT_GI_160);
+#endif
 		break;
 	case IEEE80211_STA_RX_BW_80:
 		bw_mode = RTW89_CHANNEL_WIDTH_80;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		sgi = sta->vht_cap.vht_supported &&
 		      (sta->vht_cap.cap & IEEE80211_VHT_CAP_SHORT_GI_80);
+#else
+		sgi = sta->deflink.vht_cap.vht_supported &&
+		      (sta->deflink.vht_cap.cap & IEEE80211_VHT_CAP_SHORT_GI_80);
+#endif
 		break;
 	case IEEE80211_STA_RX_BW_40:
 		bw_mode = RTW89_CHANNEL_WIDTH_40;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		sgi = sta->ht_cap.ht_supported &&
 		      (sta->ht_cap.cap & IEEE80211_HT_CAP_SGI_40);
+#else
+		sgi = sta->deflink.ht_cap.ht_supported &&
+		      (sta->deflink.ht_cap.cap & IEEE80211_HT_CAP_SGI_40);
+#endif
 		break;
 	default:
 		bw_mode = RTW89_CHANNEL_WIDTH_20;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 		sgi = sta->ht_cap.ht_supported &&
 		      (sta->ht_cap.cap & IEEE80211_HT_CAP_SGI_20);
+#else
+		sgi = sta->deflink.ht_cap.ht_supported &&
+		      (sta->deflink.ht_cap.cap & IEEE80211_HT_CAP_SGI_20);
+#endif
 		break;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	if (sta->he_cap.he_cap_elem.phy_cap_info[3] &
 	    IEEE80211_HE_PHY_CAP3_DCM_MAX_CONST_RX_16_QAM)
+#else
+	if (sta->deflink.he_cap.he_cap_elem.phy_cap_info[3] &
+	    IEEE80211_HE_PHY_CAP3_DCM_MAX_CONST_RX_16_QAM)
+#endif
 		ra->dcm_cap = 1;
 
 	if (rate_pattern->enable) {
@@ -346,7 +452,11 @@ static void rtw89_phy_ra_sta_update(struct rtw89_dev *rtwdev,
 	ra->macid = rtwsta->mac_id;
 	ra->stbc_cap = stbc_en;
 	ra->ldpc_cap = ldpc_en;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 	ra->ss_num = min(sta->rx_nss, rtwdev->hal.tx_nss) - 1;
+#else
+	ra->ss_num = min(sta->deflink.rx_nss, rtwdev->hal.tx_nss) - 1;
+#endif
 	ra->en_sgi = sgi;
 	ra->ra_mask = ra_mask;
 


### PR DESCRIPTION
The struct ieee80211_sta has changed in 5.19.x kernels