### PR TITLE
rtw89: Fix builds for kernel 6.0

### DIFF
--- a/cam.c
+++ b/cam.c
@@ -679,7 +679,11 @@ void rtw89_cam_fill_addr_cam_info(struct rtw89_dev *rtwdev,
 	FWCMD_SET_ADDR_FRM_TGT_IND(cmd, rtwvif->frm_tgt_ind);
 	FWCMD_SET_ADDR_MACID(cmd, rtwsta ? rtwsta->mac_id : rtwvif->mac_id);
 	if (rtwvif->net_type == RTW89_NET_TYPE_INFRA)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+		FWCMD_SET_ADDR_AID12(cmd, vif->cfg.aid & 0xfff);
+#else
 		FWCMD_SET_ADDR_AID12(cmd, vif->bss_conf.aid & 0xfff);
+#endif
 	else if (rtwvif->net_type == RTW89_NET_TYPE_AP_MODE)
 		FWCMD_SET_ADDR_AID12(cmd, sta ? sta->aid & 0xfff : 0);
 	FWCMD_SET_ADDR_WOL_PATTERN(cmd, rtwvif->wowlan_pattern);

--- a/core.h
+++ b/core.h
@@ -3448,7 +3448,11 @@ void rtw89_chip_cfg_txpwr_ul_tb_offset(struct rtw89_dev *rtwdev,
 	struct rtw89_vif *rtwvif = (struct rtw89_vif *)vif->drv_priv;
 	const struct rtw89_chip_info *chip = rtwdev->chip;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+	if (!vif->bss_conf.he_support || !vif->cfg.assoc)
+#else
 	if (!vif->bss_conf.he_support || !vif->bss_conf.assoc)
+#endif
 		return;
 
 	if (chip->ops->set_txpwr_ul_tb_offset)

--- a/fw.c
+++ b/fw.c
@@ -985,7 +985,12 @@ int rtw89_fw_h2c_update_beacon(struct rtw89_dev *rtwdev,
 	u16 tim_offset;
 	int bcn_total_len;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+	skb_beacon = ieee80211_beacon_get_tim(rtwdev->hw, vif, &tim_offset,
+                                              NULL, 0);
+#else
 	skb_beacon = ieee80211_beacon_get_tim(rtwdev->hw, vif, &tim_offset, NULL);
+#endif
 	if (!skb_beacon) {
 		rtw89_err(rtwdev, "failed to get beacon skb\n");
 		return -ENOMEM;

--- a/mac80211.c
+++ b/mac80211.c
@@ -334,9 +334,13 @@ static void rtw89_station_mode_sta_assoc(struct rtw89_dev *rtwdev,
 }
 
 static void rtw89_ops_bss_info_changed(struct ieee80211_hw *hw,
-				       struct ieee80211_vif *vif,
-				       struct ieee80211_bss_conf *conf,
+                                       struct ieee80211_vif *vif,
+                                       struct ieee80211_bss_conf *conf,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+                                       u64 changed)
+#else
 				       u32 changed)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 	struct rtw89_vif *rtwvif = (struct rtw89_vif *)vif->drv_priv;
@@ -345,7 +349,11 @@ static void rtw89_ops_bss_info_changed(struct ieee80211_hw *hw,
 	rtw89_leave_ps_mode(rtwdev);
 
 	if (changed & BSS_CHANGED_ASSOC) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+		if (vif->cfg.assoc) {
+#else
 		if (conf->assoc) {
+#endif
 			rtw89_station_mode_sta_assoc(rtwdev, vif, conf);
 			rtw89_phy_set_bss_color(rtwdev, vif);
 			rtw89_chip_cfg_txpwr_ul_tb_offset(rtwdev, vif);
@@ -381,7 +389,13 @@ static void rtw89_ops_bss_info_changed(struct ieee80211_hw *hw,
 	mutex_unlock(&rtwdev->mutex);
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+static int rtw89_ops_start_ap(struct ieee80211_hw *hw,
+                              struct ieee80211_vif *vif,
+                              struct ieee80211_bss_conf *link_conf)
+#else
 static int rtw89_ops_start_ap(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 	struct rtw89_vif *rtwvif = (struct rtw89_vif *)vif->drv_priv;
@@ -400,8 +414,14 @@ static int rtw89_ops_start_ap(struct ieee80211_hw *hw, struct ieee80211_vif *vif
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+static
+void rtw89_ops_stop_ap(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+                       struct ieee80211_bss_conf *link_conf)
+#else
 static
 void rtw89_ops_stop_ap(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 	struct rtw89_vif *rtwvif = (struct rtw89_vif *)vif->drv_priv;
@@ -424,9 +444,16 @@ static int rtw89_ops_set_tim(struct ieee80211_hw *hw, struct ieee80211_sta *sta,
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+static int rtw89_ops_conf_tx(struct ieee80211_hw *hw,
+                             struct ieee80211_vif *vif,
+                             unsigned int link_id, u16 ac,
+                             const struct ieee80211_tx_queue_params *params)
+#else
 static int rtw89_ops_conf_tx(struct ieee80211_hw *hw,
 			     struct ieee80211_vif *vif, u16 ac,
 			     const struct ieee80211_tx_queue_params *params)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 	struct rtw89_vif *rtwvif = (struct rtw89_vif *)vif->drv_priv;

--- a/phy.c
+++ b/phy.c
@@ -3479,7 +3479,11 @@ void rtw89_phy_set_bss_color(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif
 	enum rtw89_phy_idx phy_idx = RTW89_PHY_0;
 	u8 bss_color;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+	if (!vif->bss_conf.he_support || !vif->cfg.assoc)
+#else
 	if (!vif->bss_conf.he_support || !vif->bss_conf.assoc)
+#endif
 		return;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)  && SUSE == 0
@@ -3492,8 +3496,13 @@ void rtw89_phy_set_bss_color(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif
 			      phy_idx);
 	rtw89_phy_write32_idx(rtwdev, R_BSS_CLR_MAP, B_BSS_CLR_MAP_TGT, bss_color,
 			      phy_idx);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+	rtw89_phy_write32_idx(rtwdev, R_BSS_CLR_MAP, B_BSS_CLR_MAP_STAID,
+			      vif->cfg.aid, phy_idx);
+#else
 	rtw89_phy_write32_idx(rtwdev, R_BSS_CLR_MAP, B_BSS_CLR_MAP_STAID,
 			      vif->bss_conf.aid, phy_idx);
+#endif
 }
 
 static void


### PR DESCRIPTION
Not tested either on 6.0 kernel up to now but builds with no warnings.