### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ endif
 	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw89pci.ko
 	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852a.ko
 	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852ae.ko
+	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852b.ko
+	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852be.ko
+	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852c.ko
+	@$(KSRC)/scripts/sign-file sha256 MOK.priv MOK.der rtw_8852ce.ko
 
 sign-install: all sign install
 


### PR DESCRIPTION
I'm as a 8852be owner had faced with the issue of unavailable wifi tool after sign-install command completed.
Discovered that be/ce driver files just not signed via Makefile.
PR resolving the issue.