### PR TITLE
Add use for FIRMWAREDIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 KVER  ?= $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
-FIRMWAREDIR := /lib/firmware/
+FIRMWAREDIR := /lib/firmware
 PWD := $(shell pwd)
 CLR_MODULE_FILES := *.mod.c *.mod *.o .*.cmd *.ko *~ .tmp_versions* modules.order Module.symvers
 SYMBOL_FILE := Module.symvers
@@ -97,15 +97,15 @@ ifeq ($(COMPRESS_XZ), y)
 endif
 	@depmod -a $(KVER)
 
-	@mkdir -p /lib/firmware/rtw89/
-ifeq ("","$(wildcard /lib/firmware/rtw89/rtw8852a_fw.*)")
-	@cp rtw8852a_fw.bin /lib/firmware/rtw89/.
+	@mkdir -p $(FIRMWAREDIR)/rtw89/
+ifeq ("","$(wildcard $(FIRMWAREDIR)/rtw89/rtw8852a_fw.*)")
+	@cp rtw8852a_fw.bin $(FIRMWAREDIR)/rtw89/.
 endif
-ifeq ("","$(wildcard /lib/firmware/rtw89/rtw8852b_fw.*)")
-	@cp rtw8852b_fw.bin /lib/firmware/rtw89/.
+ifeq ("","$(wildcard $(FIRMWAREDIR)/rtw89/rtw8852b_fw.*)")
+	@cp rtw8852b_fw.bin $(FIRMWAREDIR)/rtw89/.
 endif
-ifeq ("","$(wildcard /lib/firmware/rtw89/rtw8852c_fw.*)")
-	@cp rtw8852c_fw.bin /lib/firmware/rtw89/.
+ifeq ("","$(wildcard $(FIRMWAREDIR)/rtw89/rtw8852c_fw.*)")
+	@cp rtw8852c_fw.bin $(FIRMWAREDIR)/rtw89/.
 endif
 
 	@echo "Install rtw89 SUCCESS"


### PR DESCRIPTION
Hello there! :wave: 

I'm pushing this PR to create the possibility of overriding the `FIRMWAREDIR` variable. I noticed this when building a `SlackBuild` package and noted that I couldn't redirect the firmware files' output to my build directory.

Thanks for this work! - with it, I was able to connect my ThinkPad L14 to the Internet and push this PR using the Realtek device :1st_place_medal: 