### PR TITLE
rtw89: Fix build for kernel < 5.19.0

### DIFF
--- a/core.c
+++ b/core.c
@@ -490,7 +490,7 @@ rtw89_core_tx_update_ampdu_info(struct rtw89_dev *rtwdev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0) || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 0)))
 			  4 << sta->deflink.ht_cap.ampdu_factor) - 1);
 #else
-			  4 << sta->ht_cap.ampdu_factor - 1;
+			  4 << sta->ht_cap.ampdu_factor) - 1);
 #endif
 
 	desc_info->agg_en = true;


### PR DESCRIPTION
Build fails on kernel < 5.19.0

```console
/data/source/rtw89/core.c: In function ‘rtw89_core_tx_update_ampdu_info’:
/data/source/rtw89/core.c:493:57: warning: suggest parentheses around ‘-’ inside ‘<<’ [-Wparentheses]
  493 |                           4 << sta->ht_cap.ampdu_factor - 1;
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/data/source/rtw89/core.c:493:60: error: expected ‘)’ before ‘;’ token
  493 |                           4 << sta->ht_cap.ampdu_factor - 1;
      |                                                            ^
      |                                                            )
/data/source/rtw89/core.c:488:26: note: to match this ‘(’
  488 |         ampdu_num = (u8)((rtwsta->ampdu_params[tid].agg_num ?
      |                          ^
/data/source/rtw89/core.c:502:42: error: expected ‘)’ before ‘}’ token
  502 |         desc_info->ampdu_num = ampdu_num;
      |                                          ^
      |                                          )
  503 | }
      | ~
/data/source/rtw89/core.c:488:25: note: to match this ‘(’
  488 |         ampdu_num = (u8)((rtwsta->ampdu_params[tid].agg_num ?
      |                         ^
/data/source/rtw89/core.c:502:42: error: expected ‘;’ before ‘}’ token
  502 |         desc_info->ampdu_num = ampdu_num;
      |                                          ^
      |                                          ;
  503 | }
      | ~
make[2]: *** [scripts/Makefile.build:286: /data/source/rtw89/core.o] Error 1
make[1]: *** [Makefile:1855: /data/source/rtw89] Error 2
make: *** [Makefile:95: all] Error 2
```

