### PR TITLE
Fix '==' syntax error in suspend_rtw89

### DIFF
--- a/suspend_rtw89
+++ b/suspend_rtw89
@@ -1,6 +1,5 @@
 #!/bin/sh
-if [ "${1}" == "pre" ]; then
-  modprobe -rv rtw_8852ae
-elif [ "${1}" == "post" ]; then
-  modprobe -v rtw_8852ae
-fi
+case "$1" in
+pre) modprobe -rv rtw_8852ae ;;
+post) modprobe -v rtw_8852ae ;;
+esac


### PR DESCRIPTION
`==` operator is not valid for `[` command in shell. Should be using `=`.

...but `case` is much cleaner for those kind of tasks, so I just replaced the whole thing.