### PR TITLE
fix a function to work with ubuntu + kernel 6.11.0_29

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -66,7 +66,7 @@ static int rtw89_ops_start(struct ieee80211_hw *hw)
 	return ret;
 }
 
-static void rtw89_ops_stop(struct ieee80211_hw *hw)
+static void rtw89_ops_stop(struct ieee80211_hw *hw, bool suspend)
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 

--- a/mac80211.c
+++ b/mac80211.c
@@ -15,6 +15,8 @@
 #include "ser.h"
 #include "util.h"
 #include "wow.h"
+#include <linux/version.h>
+
 
 static void rtw89_ops_tx(struct ieee80211_hw *hw,
 			 struct ieee80211_tx_control *control,
@@ -66,7 +68,12 @@ static int rtw89_ops_start(struct ieee80211_hw *hw)
 	return ret;
 }
 
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0)
 static void rtw89_ops_stop(struct ieee80211_hw *hw, bool suspend)
+#else
+static void rtw89_ops_stop(struct ieee80211_hw *hw)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 


### PR DESCRIPTION
on running 

` sudo make install `

an error shows up - 


````
error: initialization of ‘void (*)(struct ieee80211_hw , bool)’ {aka ‘void ()(struct ieee80211_hw , Bool)’} from incompatible pointer type ‘void ()(struct ieee80211hw )’ [-Werror=incompatible-pointer-types]
 1177 |         .stop                   = rtw89_ops_stop,
      |                                   ^~~~~~~~~~~~~~
/rtw89/mac80211.c:1177:35: note: (near initialization for ‘rtw89_ops.stop’)
cc1: some warnings being treated as errors
make[3]: ** [scripts/Makefile.build:244: /home/chhax1618/rtw89/mac80211.o] Error 1
make[2]:  [/usr/src/linux-headers-6.11.0-29-generic/Makefile:1938: /home/chhax1618/rtw89] Error 2
make[1]:  [Makefile:224: sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.11.0-29-generic'
make: * [Makefile:104: all] Error 2
make -C /lib/modules/6.11.0-29-generic/build M=/home/chhax1618/rtw89 modules
make[1]: Entering directory '/usr/src/linux-headers-6.11.0-29-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
  You are using:           gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
  CC [M]  

````

This is a breaking change introduced in newer kernel versions. The older ones did NOT have the bool parameter, but the newer ones expect those. So, as needed, I have added the parameter for 6.10 and above kernel versions.