### PR TITLE
Improve rtw89 P2P discovery for Miracast

### DIFF
--- a/core.c
+++ b/core.c
@@ -25,6 +25,18 @@ static bool rtw89_disable_ps_mode;
 module_param_named(disable_ps_mode, rtw89_disable_ps_mode, bool, 0644);
 MODULE_PARM_DESC(disable_ps_mode, "Set Y to disable low power mode");
 
+static bool rtw89_force_8852b_chanctx = true;
+module_param_named(force_8852b_chanctx, rtw89_force_8852b_chanctx, bool, 0644);
+MODULE_PARM_DESC(force_8852b_chanctx, "Set N to disable experimental RTL8852B channel contexts");
+
+static bool rtw89_disable_8852b_roc;
+module_param_named(disable_8852b_roc, rtw89_disable_8852b_roc, bool, 0644);
+MODULE_PARM_DESC(disable_8852b_roc, "Set Y to disable experimental RTL8852B remain-on-channel ops");
+
+static bool rtw89_disable_p2p_no_cck = true;
+module_param_named(disable_p2p_no_cck, rtw89_disable_p2p_no_cck, bool, 0644);
+MODULE_PARM_DESC(disable_p2p_no_cck, "Set Y to keep CCK enabled during P2P/WFD discovery");
+
 #define RTW89_DEF_CHAN(_freq, _hw_val, _flags, _band)	\
 	{ .center_freq = _freq, .hw_value = _hw_val, .flags = _flags, .band = _band, }
 #define RTW89_DEF_CHAN_2G(_freq, _hw_val)	\
@@ -38,6 +50,9 @@ MODULE_PARM_DESC(disable_ps_mode, "Set Y to disable low power mode");
 
 #define RTW89_WLAN_OUI_TYPE_WFA_WFD 0x0a
 #define RTW89_RRSR_OFDM_EN 2
+
+static void rtw89_core_p2p_scan_no_cck(struct rtw89_dev *rtwdev,
+				       struct rtw89_vif *rtwvif, bool enable);
 
 static struct ieee80211_channel rtw89_channels_2ghz[] = {
 	RTW89_DEF_CHAN_2G(2412, 1),
@@ -3048,9 +3063,17 @@ void rtw89_roc_start(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif)
 	struct rtw89_roc *roc = &rtwvif->roc;
 	struct cfg80211_chan_def roc_chan;
 	struct rtw89_vif *tmp;
+	bool p2p_roc;
 	int ret;
 
 	lockdep_assert_held(&rtwdev->mutex);
+
+	p2p_roc = rtwvif->wifi_role == RTW89_WIFI_ROLE_P2P_DEVICE;
+
+	rtw89_debug(rtwdev, RTW89_DBG_CHAN,
+		    "ROC start: role=%d p2p=%d sub=%d freq=%d dur=%d type=%d\n",
+		    rtwvif->wifi_role, p2p_roc, rtwvif->sub_entity_idx,
+		    roc->chan.center_freq, roc->duration, roc->type);
 
 	rtw89_leave_ips_by_hwflags(rtwdev);
 	rtw89_leave_lps(rtwdev);
@@ -3068,6 +3091,16 @@ void rtw89_roc_start(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif)
 	cfg80211_chandef_create(&roc_chan, &roc->chan, NL80211_CHAN_NO_HT);
 	rtw89_config_roc_chandef(rtwdev, rtwvif->sub_entity_idx, &roc_chan);
 	rtw89_set_channel(rtwdev);
+
+	if (p2p_roc) {
+		rtw89_core_p2p_scan_no_cck(rtwdev, rtwvif, true);
+		rtw89_btc_ntfy_scan_start(rtwdev, RTW89_PHY_0,
+					   rtw89_nl80211_to_hw_band(roc->chan.band));
+		rtw89_chip_rfk_scan(rtwdev, true);
+		rtw89_hci_recalc_int_mit(rtwdev);
+		rtw89_phy_config_edcca(rtwdev, true);
+	}
+
 	rtw89_write32_clr(rtwdev,
 			  rtw89_mac_reg_by_idx(rtwdev, mac->rx_fltr, RTW89_MAC_0),
 			  B_AX_A_UC_CAM_MATCH | B_AX_A_BC_CAM_MATCH);
@@ -3084,9 +3117,17 @@ void rtw89_roc_end(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif)
 	struct ieee80211_hw *hw = rtwdev->hw;
 	struct rtw89_roc *roc = &rtwvif->roc;
 	struct rtw89_vif *tmp;
+	bool p2p_roc;
 	int ret;
 
 	lockdep_assert_held(&rtwdev->mutex);
+
+	p2p_roc = rtwvif->wifi_role == RTW89_WIFI_ROLE_P2P_DEVICE;
+
+	rtw89_debug(rtwdev, RTW89_DBG_CHAN,
+		    "ROC end: role=%d p2p=%d sub=%d state=%d\n",
+		    rtwvif->wifi_role, p2p_roc, rtwvif->sub_entity_idx,
+		    roc->state);
 
 	ieee80211_remain_on_channel_expired(hw);
 
@@ -3099,6 +3140,14 @@ void rtw89_roc_end(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif)
 			   rtwdev->hal.rx_fltr);
 
 	roc->state = RTW89_ROC_IDLE;
+
+	if (p2p_roc) {
+		rtw89_chip_rfk_scan(rtwdev, false);
+		rtw89_btc_ntfy_scan_finish(rtwdev, RTW89_PHY_0);
+		rtw89_phy_config_edcca(rtwdev, false);
+		rtw89_core_p2p_scan_no_cck(rtwdev, rtwvif, false);
+	}
+
 	rtw89_config_roc_chandef(rtwdev, rtwvif->sub_entity_idx, NULL);
 	rtw89_chanctx_proceed(rtwdev);
 	ret = rtw89_core_send_nullfunc(rtwdev, rtwvif, true, false);
@@ -4364,6 +4413,7 @@ void rtw89_core_stop(struct rtw89_dev *rtwdev)
 	cancel_work_sync(&btc->dhcp_notify_work);
 	cancel_work_sync(&btc->icmp_notify_work);
 	cancel_delayed_work_sync(&rtwdev->txq_reinvoke_work);
+	cancel_delayed_work_sync(&rtwdev->hw_scan_timeout_work);
 	cancel_delayed_work_sync(&rtwdev->track_work);
 	cancel_delayed_work_sync(&rtwdev->chanctx_work);
 	cancel_delayed_work_sync(&rtwdev->coex_act1_work);
@@ -4401,6 +4451,7 @@ int rtw89_core_init(struct rtw89_dev *rtwdev)
 	INIT_WORK(&rtwdev->ba_work, rtw89_core_ba_work);
 	INIT_WORK(&rtwdev->txq_work, rtw89_core_txq_work);
 	INIT_DELAYED_WORK(&rtwdev->txq_reinvoke_work, rtw89_core_txq_reinvoke_work);
+	INIT_DELAYED_WORK(&rtwdev->hw_scan_timeout_work, rtw89_hw_scan_timeout_work);
 	INIT_DELAYED_WORK(&rtwdev->track_work, rtw89_track_work);
 	INIT_DELAYED_WORK(&rtwdev->chanctx_work, rtw89_chanctx_work);
 	INIT_DELAYED_WORK(&rtwdev->coex_act1_work, rtw89_coex_act1_work);
@@ -4476,6 +4527,15 @@ static void rtw89_core_p2p_scan_no_cck(struct rtw89_dev *rtwdev,
 	case RTL8851B:
 		break;
 	default:
+		return;
+	}
+
+	/* Some WFD sinks reply to P2P probes using CCK rates on 2.4 GHz. */
+	if (rtw89_disable_p2p_no_cck) {
+		rtwdev->p2p_no_cck_scan = false;
+		if (enable)
+			rtw89_debug(rtwdev, RTW89_DBG_TXRX,
+				    "P2P scan keeps CCK enabled\n");
 		return;
 	}
 
@@ -4869,6 +4929,7 @@ struct rtw89_dev *rtw89_alloc_ieee80211_hw(struct device *device,
 	struct ieee80211_ops *ops;
 	u32 driver_data_size;
 	int fw_format = -1;
+	bool has_chanctx_fw;
 	bool no_chanctx;
 
 	firmware = rtw89_early_fw_feature_recognize(device, chip, &early_fw, &fw_format);
@@ -4878,9 +4939,15 @@ struct rtw89_dev *rtw89_alloc_ieee80211_hw(struct device *device,
 		goto err;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)
-	no_chanctx = chip->support_chanctx_num == 0 ||
-		     !RTW89_CHK_FW_FEATURE(SCAN_OFFLOAD, &early_fw) ||
-		     !RTW89_CHK_FW_FEATURE(BEACON_FILTER, &early_fw);
+	has_chanctx_fw = RTW89_CHK_FW_FEATURE(SCAN_OFFLOAD, &early_fw) &&
+			 RTW89_CHK_FW_FEATURE(BEACON_FILTER, &early_fw);
+	if (!has_chanctx_fw &&
+	    chip->chip_id == RTL8852B &&
+	    rtw89_force_8852b_chanctx &&
+	    RTW89_CHK_FW_FEATURE(SCAN_OFFLOAD, &early_fw))
+		has_chanctx_fw = true;
+
+	no_chanctx = chip->support_chanctx_num == 0 || !has_chanctx_fw;
 
 	if (no_chanctx) {
 		ops->add_chanctx = ieee80211_emulate_add_chanctx;
@@ -4889,6 +4956,13 @@ struct rtw89_dev *rtw89_alloc_ieee80211_hw(struct device *device,
 		ops->switch_vif_chanctx = ieee80211_emulate_switch_vif_chanctx;
 		ops->assign_vif_chanctx = NULL;
 		ops->unassign_vif_chanctx = NULL;
+		ops->remain_on_channel = NULL;
+		ops->cancel_remain_on_channel = NULL;
+	}
+
+	if (!no_chanctx &&
+	    chip->chip_id == RTL8852B &&
+	    rtw89_disable_8852b_roc) {
 		ops->remain_on_channel = NULL;
 		ops->cancel_remain_on_channel = NULL;
 	}

--- a/core.c
+++ b/core.c
@@ -36,6 +36,9 @@ MODULE_PARM_DESC(disable_ps_mode, "Set Y to disable low power mode");
 #define RTW89_DEF_CHAN_6G(_freq, _hw_val)	\
 	RTW89_DEF_CHAN(_freq, _hw_val, 0, NL80211_BAND_6GHZ)
 
+#define RTW89_WLAN_OUI_TYPE_WFA_WFD 0x0a
+#define RTW89_RRSR_OFDM_EN 2
+
 static struct ieee80211_channel rtw89_channels_2ghz[] = {
 	RTW89_DEF_CHAN_2G(2412, 1),
 	RTW89_DEF_CHAN_2G(2417, 2),
@@ -174,6 +177,10 @@ static const struct ieee80211_iface_limit rtw89_iface_limits[] = {
 			 BIT(NL80211_IFTYPE_P2P_GO) |
 			 BIT(NL80211_IFTYPE_AP),
 	},
+	{
+		.max = 1,
+		.types = BIT(NL80211_IFTYPE_P2P_DEVICE),
+	},
 };
 
 static const struct ieee80211_iface_limit rtw89_iface_limits_mcc[] = {
@@ -186,19 +193,23 @@ static const struct ieee80211_iface_limit rtw89_iface_limits_mcc[] = {
 		.types = BIT(NL80211_IFTYPE_P2P_CLIENT) |
 			 BIT(NL80211_IFTYPE_P2P_GO),
 	},
+	{
+		.max = 1,
+		.types = BIT(NL80211_IFTYPE_P2P_DEVICE),
+	},
 };
 
 static const struct ieee80211_iface_combination rtw89_iface_combs[] = {
 	{
 		.limits = rtw89_iface_limits,
 		.n_limits = ARRAY_SIZE(rtw89_iface_limits),
-		.max_interfaces = 2,
+		.max_interfaces = 3,
 		.num_different_channels = 1,
 	},
 	{
 		.limits = rtw89_iface_limits_mcc,
 		.n_limits = ARRAY_SIZE(rtw89_iface_limits_mcc),
-		.max_interfaces = 2,
+		.max_interfaces = 3,
 		.num_different_channels = 2,
 	},
 };
@@ -586,17 +597,44 @@ rtw89_core_tx_update_sec_key(struct rtw89_dev *rtwdev,
 	desc_info->wp_offset = 1; /* in unit of 8 bytes for security header */
 }
 
+static bool rtw89_core_tx_mgmt_has_p2p_wfd_ie(struct sk_buff *skb)
+{
+	struct ieee80211_hdr *hdr = (void *)skb->data;
+	size_t hdr_len;
+	const u8 *ies;
+	size_t ies_len;
+
+	if (skb->len < sizeof(*hdr))
+		return false;
+
+	if (!ieee80211_is_mgmt(hdr->frame_control))
+		return false;
+
+	hdr_len = ieee80211_hdrlen(hdr->frame_control);
+	if (skb->len <= hdr_len)
+		return false;
+
+	ies = skb->data + hdr_len;
+	ies_len = skb->len - hdr_len;
+
+	return cfg80211_find_vendor_ie(WLAN_OUI_WFA, WLAN_OUI_TYPE_WFA_P2P,
+				       ies, ies_len) ||
+	       cfg80211_find_vendor_ie(WLAN_OUI_WFA, RTW89_WLAN_OUI_TYPE_WFA_WFD,
+				       ies, ies_len);
+}
+
 static u16 rtw89_core_get_mgmt_rate(struct rtw89_dev *rtwdev,
 				    struct rtw89_core_tx_request *tx_req,
 				    const struct rtw89_chan *chan)
 {
 	struct sk_buff *skb = tx_req->skb;
 	struct ieee80211_tx_info *tx_info = IEEE80211_SKB_CB(skb);
-	struct ieee80211_vif *vif = tx_info->control.vif;
+	struct ieee80211_vif *vif = tx_info->control.vif ?: tx_req->vif;
 	u16 lowest_rate;
 
 	if (tx_info->flags & IEEE80211_TX_CTL_NO_CCK_RATE ||
-	    (vif && vif->p2p))
+	    (vif && (vif->p2p || vif->type == NL80211_IFTYPE_P2P_DEVICE)) ||
+	    rtw89_core_tx_mgmt_has_p2p_wfd_ie(skb))
 		lowest_rate = RTW89_HW_RATE_OFDM6;
 	else if (chan->band_type == RTW89_BAND_2G)
 		lowest_rate = RTW89_HW_RATE_CCK1;
@@ -650,6 +688,7 @@ rtw89_core_tx_update_mgmt_info(struct rtw89_dev *rtwdev,
 	desc_info->use_rate = true;
 	desc_info->dis_data_fb = true;
 	desc_info->data_rate = rtw89_core_get_mgmt_rate(rtwdev, tx_req, chan);
+	desc_info->data_retry_lowest_rate = desc_info->data_rate;
 
 	rtw89_debug(rtwdev, RTW89_DBG_TXRX,
 		    "tx mgmt frame with rate 0x%x on channel %d (band %d, bw %d)\n",
@@ -802,7 +841,7 @@ static u16 rtw89_core_get_data_rate(struct rtw89_dev *rtwdev,
 	if (rate_pattern->enable)
 		return rate_pattern->rate;
 
-	if (vif->p2p)
+	if (vif->p2p || vif->type == NL80211_IFTYPE_P2P_DEVICE)
 		lowest_rate = RTW89_HW_RATE_OFDM6;
 	else if (chan->band_type == RTW89_BAND_2G)
 		lowest_rate = RTW89_HW_RATE_CCK1;
@@ -3383,6 +3422,9 @@ void rtw89_vif_type_mapping(struct ieee80211_vif *vif, bool assoc)
 		else
 			rtwvif->wifi_role = RTW89_WIFI_ROLE_AP;
 		break;
+	case NL80211_IFTYPE_P2P_DEVICE:
+		rtwvif->wifi_role = RTW89_WIFI_ROLE_P2P_DEVICE;
+		break;
 	RTW89_TYPE_MAPPING(ADHOC);
 	RTW89_TYPE_MAPPING(MONITOR);
 	RTW89_TYPE_MAPPING(MESH_POINT);
@@ -3409,6 +3451,11 @@ void rtw89_vif_type_mapping(struct ieee80211_vif *vif, bool assoc)
 			rtwvif->net_type = RTW89_NET_TYPE_NO_LINK;
 			rtwvif->trigger = false;
 		}
+		rtwvif->self_role = RTW89_SELF_ROLE_CLIENT;
+		rtwvif->addr_cam.sec_ent_mode = RTW89_ADDR_CAM_SEC_NORMAL;
+		break;
+	case NL80211_IFTYPE_P2P_DEVICE:
+		rtwvif->net_type = RTW89_NET_TYPE_NO_LINK;
 		rtwvif->self_role = RTW89_SELF_ROLE_CLIENT;
 		rtwvif->addr_cam.sec_ent_mode = RTW89_ADDR_CAM_SEC_NORMAL;
 		break;
@@ -4414,6 +4461,47 @@ int rtw89_core_init(struct rtw89_dev *rtwdev)
 }
 EXPORT_SYMBOL(rtw89_core_init);
 
+static void rtw89_core_p2p_scan_no_cck(struct rtw89_dev *rtwdev,
+				       struct rtw89_vif *rtwvif, bool enable)
+{
+	u32 rate_en;
+	u32 reg;
+
+	if (rtwvif->wifi_role != RTW89_WIFI_ROLE_P2P_DEVICE)
+		return;
+
+	switch (rtwdev->chip->chip_id) {
+	case RTL8852A:
+	case RTL8852B:
+	case RTL8851B:
+		break;
+	default:
+		return;
+	}
+
+	rtwdev->p2p_no_cck_scan = enable;
+
+	if (enable && rtwdev->chip->chip_id == RTL8852B) {
+		reg = rtw89_mac_reg_by_idx(rtwdev, R_AX_TXRATE_CHK, rtwvif->mac_idx);
+		rtw89_write16_mask(rtwdev, reg, B_AX_DEFT_RATE_MASK,
+				   RTW89_HW_RATE_OFDM6);
+		rtw89_write8_set(rtwdev, reg,
+				 B_AX_CHECK_CCK_EN | B_AX_RTS_LIMIT_IN_OFDM6);
+
+		rtw89_phy_write32_mask(rtwdev, R_UPD_CLK_ADC, B_ENABLE_CCK, 0);
+		rtw89_phy_write32_mask(rtwdev, R_RXCCA, B_RXCCA_DIS, 1);
+		rtw89_debug(rtwdev, RTW89_DBG_TXRX,
+			    "P2P scan disables CCK MAC/PHY immediately\n");
+	}
+
+	rate_en = enable ? RTW89_RRSR_OFDM_EN : RRSR_OFDM_CCK_EN;
+	reg = rtw89_mac_reg_by_idx(rtwdev, R_AX_PTCL_RRSR1, rtwvif->mac_idx);
+	rtw89_write32_mask(rtwdev, reg, B_AX_RRSR_RATE_EN_MASK, rate_en);
+
+	rtw89_debug(rtwdev, RTW89_DBG_TXRX, "P2P scan %s CCK TX rates\n",
+		    enable ? "disables" : "restores");
+}
+
 void rtw89_core_deinit(struct rtw89_dev *rtwdev)
 {
 	rtw89_ser_deinit(rtwdev);
@@ -4433,6 +4521,7 @@ void rtw89_core_scan_start(struct rtw89_dev *rtwdev, struct rtw89_vif *rtwvif,
 						       rtwvif->sub_entity_idx);
 
 	rtwdev->scanning = true;
+	rtw89_core_p2p_scan_no_cck(rtwdev, rtwvif, true);
 	rtw89_leave_lps(rtwdev);
 	if (hw_scan)
 		rtw89_leave_ips_by_hwflags(rtwdev);
@@ -4460,6 +4549,7 @@ void rtw89_core_scan_complete(struct rtw89_dev *rtwdev,
 	rtw89_chip_rfk_scan(rtwdev, false);
 	rtw89_btc_ntfy_scan_finish(rtwdev, RTW89_PHY_0);
 	rtw89_phy_config_edcca(rtwdev, false);
+	rtw89_core_p2p_scan_no_cck(rtwdev, rtwvif, false);
 
 	rtwdev->scanning = false;
 	rtwdev->dig.bypass_dig = true;
@@ -4651,6 +4741,7 @@ static int rtw89_core_register_hw(struct rtw89_dev *rtwdev)
 
 	hw->wiphy->interface_modes = BIT(NL80211_IFTYPE_STATION) |
 				     BIT(NL80211_IFTYPE_AP) |
+				     BIT(NL80211_IFTYPE_P2P_DEVICE) |
 				     BIT(NL80211_IFTYPE_P2P_CLIENT) |
 				     BIT(NL80211_IFTYPE_P2P_GO);
 

--- a/core.h
+++ b/core.h
@@ -5402,6 +5402,7 @@ struct rtw89_dev {
 	struct workqueue_struct *txq_wq;
 	struct work_struct txq_work;
 	struct delayed_work txq_reinvoke_work;
+	struct delayed_work hw_scan_timeout_work;
 	/* used to protect ba_list and forbid_ba_list */
 	spinlock_t ba_lock;
 	/* txqs to setup ba session */

--- a/core.h
+++ b/core.h
@@ -5470,6 +5470,7 @@ struct rtw89_dev {
 	struct rtw89_ppdu_sts_info ppdu_sts;
 	u8 total_sta_assoc;
 	bool scanning;
+	bool p2p_no_cck_scan;
 
 	struct rtw89_regulatory_info regulatory;
 	struct rtw89_sar_info sar;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+rtw89 (1.0.2-3+local1) unstable; urgency=medium
+
+  * Improve P2P discovery for Wi-Fi Display/Miracast by advertising P2P
+    device support and keeping P2P management/scanning traffic on OFDM rates.
+  * Disable firmware scan offload to avoid stuck P2P discovery scans.
+  * Fix build against Linux 6.11+ mac80211 stop callback.
+
+ -- Codex <codex@local>  Fri, 03 Jul 2026 22:45:00 +0200
+
 rtw89 (1.0.2-3) unstable; urgency=medium
 
   * Updated debian packaging to 3.0 (quilt) format
@@ -32,4 +41,3 @@ rtw89 (1.0.0-1) unstable; urgency=medium
   * Add driver package to build DEB package support in Debian DKMS format.
 
  -- lichenggang <lichenggang@uniontech.com>  Thu, 17 Jun 2021 17:14:07 +0800
-

--- a/fw.c
+++ b/fw.c
@@ -59,6 +59,22 @@ static void rtw89_fw_c2h_cmd_handle(struct rtw89_dev *rtwdev,
 static int rtw89_h2c_tx_and_wait(struct rtw89_dev *rtwdev, struct sk_buff *skb,
 				 struct rtw89_wait_info *wait, unsigned int cond);
 
+static unsigned int rtw89_hw_scan_timeout_ms = 30000;
+module_param_named(hw_scan_timeout_ms, rtw89_hw_scan_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(hw_scan_timeout_ms, "Firmware scan offload timeout in milliseconds");
+
+#define RTW89_HW_SCAN_ABORT_TIMEOUT_MS 3000
+
+static void rtw89_hw_scan_restart_timeout(struct rtw89_dev *rtwdev,
+					  unsigned int timeout_ms)
+{
+	if (!timeout_ms)
+		return;
+
+	mod_delayed_work(system_wq, &rtwdev->hw_scan_timeout_work,
+			 msecs_to_jiffies(timeout_ms));
+}
+
 static struct sk_buff *rtw89_fw_h2c_alloc_skb(struct rtw89_dev *rtwdev, u32 len,
 					      bool header)
 {
@@ -6335,6 +6351,8 @@ void rtw89_hw_scan_complete(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 		.aborted = aborted,
 	};
 
+	cancel_delayed_work(&rtwdev->hw_scan_timeout_work);
+
 	if (!vif)
 		return;
 
@@ -6359,16 +6377,50 @@ void rtw89_hw_scan_complete(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 	rtw89_chanctx_proceed(rtwdev);
 }
 
+void rtw89_hw_scan_timeout_work(struct work_struct *work)
+{
+	struct rtw89_dev *rtwdev =
+		container_of(to_delayed_work(work), struct rtw89_dev,
+			     hw_scan_timeout_work);
+	struct ieee80211_vif *vif;
+	int ret;
+
+	mutex_lock(&rtwdev->mutex);
+
+	vif = rtwdev->scan_info.scanning_vif;
+	if (!vif)
+		goto out;
+
+	rtw89_warn(rtwdev, "HW scan timed out; forcing abort\n");
+	rtwdev->scan_info.abort = true;
+
+	ret = rtw89_hw_scan_offload(rtwdev, vif, false);
+	if (ret)
+		rtw89_warn(rtwdev, "failed to stop timed out HW scan: %d\n", ret);
+
+	rtw89_hw_scan_complete(rtwdev, vif, true);
+
+out:
+	mutex_unlock(&rtwdev->mutex);
+}
+
 void rtw89_hw_scan_abort(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif)
 {
 	struct rtw89_hw_scan_info *scan_info = &rtwdev->scan_info;
+	unsigned int timeout_ms;
 	int ret;
 
 	scan_info->abort = true;
 
 	ret = rtw89_hw_scan_offload(rtwdev, vif, false);
-	if (ret)
+	if (ret) {
 		rtw89_hw_scan_complete(rtwdev, vif, true);
+		return;
+	}
+
+	timeout_ms = min_t(unsigned int, rtw89_hw_scan_timeout_ms,
+			   RTW89_HW_SCAN_ABORT_TIMEOUT_MS);
+	rtw89_hw_scan_restart_timeout(rtwdev, timeout_ms);
 }
 
 static bool rtw89_is_any_vif_connected_or_connecting(struct rtw89_dev *rtwdev)
@@ -6417,6 +6469,8 @@ int rtw89_hw_scan_offload(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 	}
 
 	ret = mac->scan_offload(rtwdev, &opt, rtwvif);
+	if (!ret && enable && rtw89_hw_scan_timeout_ms)
+		rtw89_hw_scan_restart_timeout(rtwdev, rtw89_hw_scan_timeout_ms);
 out:
 	return ret;
 }

--- a/fw.h
+++ b/fw.h
@@ -4438,6 +4438,7 @@ void rtw89_hw_scan_start(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 			 struct ieee80211_scan_request *req);
 void rtw89_hw_scan_complete(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 			    bool aborted);
+void rtw89_hw_scan_timeout_work(struct work_struct *work);
 int rtw89_hw_scan_offload(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif,
 			  bool enable);
 void rtw89_hw_scan_abort(struct rtw89_dev *rtwdev, struct ieee80211_vif *vif);

--- a/mac80211.c
+++ b/mac80211.c
@@ -16,6 +16,16 @@
 #include "util.h"
 #include "wow.h"
 
+static bool rtw89_disable_hw_scan;
+module_param_named(disable_hw_scan, rtw89_disable_hw_scan, bool, 0644);
+MODULE_PARM_DESC(disable_hw_scan, "Set Y to disable firmware scan offload");
+
+static bool rtw89_disable_p2p_hw_scan;
+module_param_named(disable_p2p_hw_scan, rtw89_disable_p2p_hw_scan, bool, 0644);
+MODULE_PARM_DESC(disable_p2p_hw_scan, "Set Y to use software scan for P2P/WFD discovery");
+
+#define RTW89_WLAN_OUI_TYPE_WFA_WFD 0x0a
+
 static void rtw89_ops_tx(struct ieee80211_hw *hw,
 			 struct ieee80211_tx_control *control,
 			 struct sk_buff *skb)
@@ -902,8 +912,54 @@ static void rtw89_ops_reconfig_complete(struct ieee80211_hw *hw,
 static int rtw89_ops_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 			     struct ieee80211_scan_request *req)
 {
-	/* Firmware scan offload can leave P2P discovery scans stuck forever. */
-	return 1;
+	struct rtw89_dev *rtwdev = hw->priv;
+	struct rtw89_vif *rtwvif = vif_to_rtwvif_safe(vif);
+	struct cfg80211_scan_request *scan_req = &req->req;
+	bool p2p_scan = false;
+	int ret = 0;
+
+	if (rtw89_disable_hw_scan)
+		return 1;
+
+	if (!RTW89_CHK_FW_FEATURE(SCAN_OFFLOAD, &rtwdev->fw))
+		return 1;
+
+	if (!vif || !rtwvif)
+		return 1;
+
+	if (vif->type == NL80211_IFTYPE_P2P_DEVICE || vif->p2p)
+		p2p_scan = true;
+
+	if (!p2p_scan && scan_req->ie && scan_req->ie_len) {
+		p2p_scan = cfg80211_find_vendor_ie(WLAN_OUI_WFA,
+						   WLAN_OUI_TYPE_WFA_P2P,
+						   scan_req->ie,
+						   scan_req->ie_len) ||
+			   cfg80211_find_vendor_ie(WLAN_OUI_WFA,
+						   RTW89_WLAN_OUI_TYPE_WFA_WFD,
+						   scan_req->ie,
+						   scan_req->ie_len);
+	}
+
+	if (p2p_scan && rtw89_disable_p2p_hw_scan) {
+		rtw89_debug(rtwdev, RTW89_DBG_FW,
+			    "use software scan for P2P/WFD discovery\n");
+		return 1;
+	}
+
+	if (rtwdev->scanning || rtwvif->offchan)
+		return -EBUSY;
+
+	mutex_lock(&rtwdev->mutex);
+	rtw89_hw_scan_start(rtwdev, vif, req);
+	ret = rtw89_hw_scan_offload(rtwdev, vif, true);
+	if (ret) {
+		rtw89_hw_scan_abort(rtwdev, vif);
+		rtw89_err(rtwdev, "HW scan failed with status: %d\n", ret);
+	}
+	mutex_unlock(&rtwdev->mutex);
+
+	return ret;
 }
 
 static void rtw89_ops_cancel_hw_scan(struct ieee80211_hw *hw,

--- a/mac80211.c
+++ b/mac80211.c
@@ -66,7 +66,11 @@ static int rtw89_ops_start(struct ieee80211_hw *hw)
 	return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void rtw89_ops_stop(struct ieee80211_hw *hw, bool suspend)
+#else
 static void rtw89_ops_stop(struct ieee80211_hw *hw)
+#endif
 {
 	struct rtw89_dev *rtwdev = hw->priv;
 
@@ -898,26 +902,8 @@ static void rtw89_ops_reconfig_complete(struct ieee80211_hw *hw,
 static int rtw89_ops_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 			     struct ieee80211_scan_request *req)
 {
-	struct rtw89_dev *rtwdev = hw->priv;
-	struct rtw89_vif *rtwvif = vif_to_rtwvif_safe(vif);
-	int ret = 0;
-
-	if (!RTW89_CHK_FW_FEATURE(SCAN_OFFLOAD, &rtwdev->fw))
-		return 1;
-
-	if (rtwdev->scanning || rtwvif->offchan)
-		return -EBUSY;
-
-	mutex_lock(&rtwdev->mutex);
-	rtw89_hw_scan_start(rtwdev, vif, req);
-	ret = rtw89_hw_scan_offload(rtwdev, vif, true);
-	if (ret) {
-		rtw89_hw_scan_abort(rtwdev, vif);
-		rtw89_err(rtwdev, "HW scan failed with status: %d\n", ret);
-	}
-	mutex_unlock(&rtwdev->mutex);
-
-	return ret;
+	/* Firmware scan offload can leave P2P discovery scans stuck forever. */
+	return 1;
 }
 
 static void rtw89_ops_cancel_hw_scan(struct ieee80211_hw *hw,

--- a/rtw8852b.c
+++ b/rtw8852b.c
@@ -910,12 +910,23 @@ static void rtw8852b_set_channel_mac(struct rtw89_dev *rtwdev,
 
 	if (chan->channel > 14) {
 		rtw89_write8_clr(rtwdev, chk_rate, B_AX_BAND_MODE);
+		rtw89_write16_mask(rtwdev, chk_rate, B_AX_DEFT_RATE_MASK,
+				   RTW89_HW_RATE_OFDM6);
 		rtw89_write8_set(rtwdev, chk_rate,
 				 B_AX_CHECK_CCK_EN | B_AX_RTS_LIMIT_IN_OFDM6);
 	} else {
 		rtw89_write8_set(rtwdev, chk_rate, B_AX_BAND_MODE);
-		rtw89_write8_clr(rtwdev, chk_rate,
-				 B_AX_CHECK_CCK_EN | B_AX_RTS_LIMIT_IN_OFDM6);
+		if (rtwdev->p2p_no_cck_scan) {
+			rtw89_write16_mask(rtwdev, chk_rate, B_AX_DEFT_RATE_MASK,
+					   RTW89_HW_RATE_OFDM6);
+			rtw89_write8_set(rtwdev, chk_rate,
+					 B_AX_CHECK_CCK_EN | B_AX_RTS_LIMIT_IN_OFDM6);
+		} else {
+			rtw89_write16_mask(rtwdev, chk_rate, B_AX_DEFT_RATE_MASK,
+					   RTW89_HW_RATE_CCK1);
+			rtw89_write8_clr(rtwdev, chk_rate,
+					 B_AX_CHECK_CCK_EN | B_AX_RTS_LIMIT_IN_OFDM6);
+		}
 	}
 }
 
@@ -1464,7 +1475,7 @@ static void rtw8852b_bb_set_pop(struct rtw89_dev *rtwdev)
 static void rtw8852b_set_channel_bb(struct rtw89_dev *rtwdev, const struct rtw89_chan *chan,
 				    enum rtw89_phy_idx phy_idx)
 {
-	bool cck_en = chan->channel <= 14;
+	bool cck_en = chan->channel <= 14 && !rtwdev->p2p_no_cck_scan;
 	u8 pri_ch_idx = chan->pri_ch_idx;
 	u8 band = chan->band_type, chan_idx;
 

--- a/rtw8852b.c
+++ b/rtw8852b.c
@@ -2621,7 +2621,7 @@ const struct rtw89_chip_info rtw8852b_chip_info = {
 	.dig_table		= NULL,
 	.dig_regs		= &rtw8852b_dig_regs,
 	.tssi_dbw_table		= NULL,
-	.support_chanctx_num	= 0,
+	.support_chanctx_num	= 2,
 	.support_rnr		= false,
 	.support_bands		= BIT(NL80211_BAND_2GHZ) |
 				  BIT(NL80211_BAND_5GHZ),


### PR DESCRIPTION
This add support for NL80211_IFTYPE_P2P_DEVICE used by Miracast.

Improve hw scan, P2P, CHK, and chanctx.
Add two canal support to allow Wifi connection and Miracast together.
Add support to Linux kernel v6.11.

Tested and work on TV Blaupunkt 43U3012.